### PR TITLE
Alliance flip for trajectories

### DIFF
--- a/src/main/java/frc/lib/util/FieldConstants.java
+++ b/src/main/java/frc/lib/util/FieldConstants.java
@@ -253,7 +253,7 @@ public class FieldConstants {
      * Flips a translation to the correct side of the field based on the current alliance color. By
      * default, all translations and poses in {@link FieldConstants} are stored with the origin at
      * the rightmost point on the BLUE ALLIANCE wall.
-     * 
+     *
      * @param translation Initial Translation
      * @return Translation appropriate for the current alliance
      */
@@ -297,7 +297,7 @@ public class FieldConstants {
      * Flips a trajectory to the correct side of the field based on the current alliance color. By
      * default, all translations and poses in {@link FieldConstants} are stored with the origin at
      * the rightmost point on the BLUE ALLIANCE wall.
-     * 
+     *
      * @param traj PathPlanner-generated trajectory for the Blue Alliance
      * @return Trajectory appropriate for the current alliance
      */

--- a/src/main/java/frc/lib/util/FieldConstants.java
+++ b/src/main/java/frc/lib/util/FieldConstants.java
@@ -23,7 +23,11 @@
 
 package frc.lib.util;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
 import java.util.Map;
+import com.pathplanner.lib.PathPlannerTrajectory;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
@@ -271,6 +275,44 @@ public class FieldConstants {
         } else {
             return pose;
         }
+    }
+
+    public static PathPlannerTrajectory allianceFlip(PathPlannerTrajectory traj) {
+        var startEvent = traj.getStartStopEvent();
+        var endEvent = traj.getEndStopEvent();
+        var markers = traj.getMarkers();
+        var states = traj.getStates();
+
+        for (var state : states) {
+            state.poseMeters = allianceFlip(state.poseMeters);
+        }
+
+        for (var marker : markers) {
+            marker.positionMeters = allianceFlip(marker.positionMeters);
+        }
+
+        Constructor<PathPlannerTrajectory> constructor;
+        try {
+            constructor = PathPlannerTrajectory.class.getDeclaredConstructor(List.class, List.class,
+                PathPlannerTrajectory.StopEvent.class, PathPlannerTrajectory.StopEvent.class,
+                boolean.class);
+            constructor.setAccessible(true);
+
+            return constructor.newInstance(states, markers, startEvent, endEvent, false);
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+        } catch (SecurityException e) {
+            e.printStackTrace();
+        } catch (InstantiationException e) {
+            e.printStackTrace();
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace();
+        } catch (InvocationTargetException e) {
+            e.printStackTrace();
+        }
+        return traj;
     }
 
     /**


### PR DESCRIPTION
Adds allianceFlip for types `Rotation2d` and `PathPlannerTrajectory`. Need to test on robot to make sure it doesn't throw a `SecurityException` (since we do some hacky reflection to access private fields). 