### PR TITLE
fix processor claiming everything

### DIFF
--- a/checker/src/main/java/org/frc5572/robotools/RobotProcessor.java
+++ b/checker/src/main/java/org/frc5572/robotools/RobotProcessor.java
@@ -69,7 +69,7 @@ public class RobotProcessor extends AbstractProcessor {
         if (fatal) {
             throw new RuntimeException("Checks failed!");
         }
-        return true;
+        return false;
     }
 
 }


### PR DESCRIPTION
Currently, `RobotProcessor` claims its handled _all_ annotations, when in fact it doesn't care about annotations. This breaks things like `AutoLog` in AdvantageKit. 

This change fixes `RobotProcessor` such that it claims it handles _none_ of the annotated items (even though it technically walks the entire tree).